### PR TITLE
 added options.getUrl() feature instead of options.imagePath

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,39 +1,52 @@
-const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
-const get = require('lodash/get')
+// todo: add tests?
+const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
+const get = require("lodash/get");
 
 exports.onCreateNode = async (
   { node, actions, store, cache, createNodeId },
   options
 ) => {
-  const { createNode } = actions
+  const { createNode } = actions;
   const {
     nodeType,
     imagePath,
-    name = 'localImage',
+    getUrl,
+    name = "localImage",
     auth = {},
-    ext = null,
-  } = options
+    ext = null
+  } = options;
 
-  let fileNode
+  let fileNode;
   if (node.internal.type === nodeType) {
+
+
+    // use options.imagePath to derive url
+    // if not set, try options.getUrl()
+    let url
+    if (imagePath) {
+      url = ext ? `${get(node, imagePath)}${ext}` : get(node, imagePath);
+    } else if (typeof getUrl == 'function') {
+      url = getUrl(node);
+    }
+
     try {
       fileNode = await createRemoteFileNode({
-        url: ext ? `${get(node, imagePath)}${ext}` : get(node, imagePath),
+        url,
         parentNodeId: node.id,
         store,
         cache,
         createNode,
         createNodeId,
         auth,
-        ext,
-      })
+        ext
+      });
     } catch (e) {
-      console.error('gatsby-plugin-remote-images ERROR:', e)
+      console.error("gatsby-plugin-remote-images ERROR:", e);
     }
   }
   // Adds a field `localImage` or custom name to the node
   // ___NODE appendix tells Gatsby that this field will link to another node
   if (fileNode) {
-    node[`${name}___NODE`] = fileNode.id
+    node[`${name}___NODE`] = fileNode.id;
   }
-}
+};


### PR DESCRIPTION
example usage
```js
{
  resolve: `gatsby-plugin-remote-images`,
  options: {
    nodeType: "content",
    getUrl: node => {
      const { copy } = node;
      const { thumbnailSrc } = copy.find(o => o.thumbnailSrc !== "NA");
      return thumbnailSrc;
    },
    name: "thumbnailSrcLocal"
  }
},
```